### PR TITLE
Suppress drawing check mark when sex is not selected.

### DIFF
--- a/app.py
+++ b/app.py
@@ -243,7 +243,7 @@ def genpdf():
   cc.drawString(65,710,form_info['ruby'])
   if form_info['sex'] == 'male':
       cc.drawString(338,669,'レ')
-  else:
+  elif form_info['sex'] == 'female':
       cc.drawString(373,669,'レ')
   write_q1()
   write_yes_no(442,600,form_info['q2'])


### PR DESCRIPTION
意図的に性別を選ばない方も、"女性"とされてしまうのを抑制いたしました。