### PR TITLE
ワクチンの種類を選択するラジオボタンのレイアウトの修正

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -223,24 +223,22 @@
         </div>
         <div class="question">
           <label>今回のワクチンは何社製を接種しますか?</label>
-          <div class="mb-3 form-check">
-            <label class="form-check-label">
-              <input class="form-check-input" type="radio" name="maker" value="pfizer" id="astrano" checked>
-              Pfizer（ファイザー）・BioNTech（ビオンテック）・Fosun（復星）『コミナティComirnaty』
-            </label>
-            <label class="form-check-label">
-              <input class="form-check-input" type="radio" name="maker" value="moderna" id="astrano2">
-               Moderna（モデルナ）・武田薬品 『COVID-19 ワクチンモデルナ（スパイクバックスSpikevax）』
-            </label>
-            <label class="form-check-label">
-              <input class="form-check-input" type="radio" name="maker" value="astrazeneca" id="astrayes">
-              Astra-Zeneca（アストラゼネカ）・オックスフォード大学『バキスゼブリア(Vaxzevria)』
-            </label>
-            <label class="form-check-label">
-              <input class="form-check-input" type="radio" name="maker" value="dontknow" id="astrayes2">
-              不明，わかりません，決まっていません
-            </label>
-          </div>
+          <div class="form-check">
+                <input class="form-check-input" type="radio" name="maker" value="pfizer" id="astrano" checked>
+                <label class="form-check-label" for="astrano">Pfizer（ファイザー）・BioNTech（ビオンテック）・Fosun（復星）『コミナティComirnaty』</label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="maker" value="moderna" id="astrano2">
+                <label class="form-check-label" for="astrano2">Moderna（モデルナ）・武田薬品 『COVID-19 ワクチンモデルナ（スパイクバックスSpikevax）』</label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="maker" value="astrazeneca" id="astrayes">
+                <label class="form-check-label" for="astrayes">Astra-Zeneca（アストラゼネカ）・オックスフォード大学『バキスゼブリア(Vaxzevria)』</label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="maker" value="dontknow" id="astrayes2">
+                <label class="form-check-label" for="astrayes2">不明，わかりません，決まっていません</label>
+            </div>
         </div>
         <div class="question">
           <label><b>質問（1）</b>新型コロナワクチンを打つのは1回目ですか?</label>


### PR DESCRIPTION
ワクチンの種類を選択するラジオボタンの表示がおかしかったので、修正しました。
<修正前>
![image](https://user-images.githubusercontent.com/33191007/132972696-75625027-03d1-4be7-892f-f47eeedab947.png)
<修正後>
![image](https://user-images.githubusercontent.com/33191007/132972703-0d6d755d-9384-4f92-bcf8-7d529f02bcda.png)

自分が使おうと思ったときに、気になったので修正しました！
手書きより楽で助かります！
ありがとうございます！